### PR TITLE
use $unset instead of $set, update error

### DIFF
--- a/link_accounts_server.js
+++ b/link_accounts_server.js
@@ -85,13 +85,8 @@ Accounts.unlinkService = function (userId, serviceName, cb) {
   }
 
   if (user.services[serviceName]) {
-    var newServices = _.omit(user.services, serviceName);
-    Meteor.users.update({_id: user._id}, {$set: {services: newServices}}, function (result) {
-      if (cb && typeof cb === 'function') {
-        cb(result);
-      }
-    });
+    return Meteor.users.update({_id: user._id}, {$unset: {[`services.${serviceName}`]: ''}}, cb)
   } else {
-    throw new Meteor.Error(500, 'no service');
+    throw new Meteor.Error('no-service', 'user is not linked with this service');
   }
 };


### PR DESCRIPTION
use $unset instead of $set to remove service is more precise.
meteor error don't need to be 500(server error) since you want the client know what it is.

I didn't test the code. please check if it runs well.