### PR TITLE
Fix null options error

### DIFF
--- a/core-services/facebook.js
+++ b/core-services/facebook.js
@@ -16,7 +16,7 @@ if (Meteor.isClient) {
 
     if (!callback && typeof options === "function") {
       callback = options;
-      options = null;
+      options = {};
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);

--- a/core-services/github.js
+++ b/core-services/github.js
@@ -10,7 +10,7 @@ if (Meteor.isClient) {
 
     if (!callback && typeof options === "function") {
       callback = options;
-      options = null;
+      options = {};
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);

--- a/core-services/google.js
+++ b/core-services/google.js
@@ -10,7 +10,7 @@ if (Meteor.isClient) {
 
     if (!callback && typeof options === "function") {
       callback = options;
-      options = null;
+      options = {};
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);

--- a/core-services/meetup.js
+++ b/core-services/meetup.js
@@ -10,7 +10,7 @@ if (Meteor.isClient) {
 
     if (!callback && typeof options === "function") {
       callback = options;
-      options = null;
+      options = {};
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);

--- a/core-services/meteor_developer.js
+++ b/core-services/meteor_developer.js
@@ -10,7 +10,7 @@ if (Meteor.isClient) {
 
     if (!callback && typeof options === "function") {
       callback = options;
-      options = null;
+      options = {};
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);

--- a/core-services/twitter.js
+++ b/core-services/twitter.js
@@ -9,7 +9,7 @@ if (Meteor.isClient) {
 
     if (!callback && typeof options === "function") {
       callback = options;
-      options = null;
+      options = {};
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);

--- a/core-services/weibo.js
+++ b/core-services/weibo.js
@@ -9,7 +9,7 @@ if (Meteor.isClient) {
 
     if (!callback && typeof options === "function") {
       callback = options;
-      options = null;
+      options = {};
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);


### PR DESCRIPTION
There is an error when you pass null as options.
In meteor the first param of `Package.twitter.Twitter.requestCredential` must be an object. If you make:
```
Meteor.linkWithTwitter((err) => {
 console.log(err);
});

Meteor.linkWithTwitter();
```
It will fail on this line https://github.com/meteor/meteor/blob/devel/packages/twitter/twitter_client.js#L42 because options is null.