### PR TITLE
Add support for 'facebook-oauth' package

### DIFF
--- a/core-services/facebook.js
+++ b/core-services/facebook.js
@@ -4,13 +4,21 @@ if (Meteor.isClient) {
     if (!Meteor.userId()) {
       throw new Meteor.Error(402, 'Please login to an existing account before link.');
     }
+    
+    var facebookPackage;
+    if (Package.facebook) {
+      facebookPackge = Package.facebook;
+    } else if (Package['facebook-oauth']) {
+      facebookPackge = Package['facebook-oauth'];
+    }
+    
     if (Meteor.isCordova) {
       if (!Package['btafel:accounts-facebook-cordova']) {
         throw new Meteor.Error(403, 'Please include btafel:accounts-facebook-cordova package or cordova-fb package')
       }
     } else {
-      if(!Package['accounts-facebook'] || !Package['facebook']) {
-        throw new Meteor.Error(403, 'Please include accounts-facebook and facebook package or cordova-fb package')
+      if (!Package['accounts-facebook'] || !facebookPackge) {
+        throw new Meteor.Error(403, 'Please include accounts-facebook and facebook-oauth package or cordova-fb package')
       }
     }
 
@@ -20,6 +28,6 @@ if (Meteor.isClient) {
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);
-    Package.facebook.Facebook.requestCredential(options, credentialRequestCompleteCallback);
+    facebookPackage.Facebook.requestCredential(options, credentialRequestCompleteCallback);
   };
 }

--- a/core-services/facebook.js
+++ b/core-services/facebook.js
@@ -7,9 +7,9 @@ if (Meteor.isClient) {
     
     var facebookPackage;
     if (Package.facebook) {
-      facebookPackge = Package.facebook;
+      facebookPackage = Package.facebook;
     } else if (Package['facebook-oauth']) {
-      facebookPackge = Package['facebook-oauth'];
+      facebookPackage = Package['facebook-oauth'];
     }
     
     if (Meteor.isCordova) {
@@ -17,7 +17,7 @@ if (Meteor.isClient) {
         throw new Meteor.Error(403, 'Please include btafel:accounts-facebook-cordova package or cordova-fb package')
       }
     } else {
-      if (!Package['accounts-facebook'] || !facebookPackge) {
+      if (!Package['accounts-facebook'] || !facebookPackage) {
         throw new Meteor.Error(403, 'Please include accounts-facebook and facebook-oauth package or cordova-fb package')
       }
     }


### PR DESCRIPTION
The meteor team changed the name from the core Facebook package to `facebook-oauth`. This change may be necessary for the other oauth packages as well.