### PR TITLE
Rename google oauth package

### DIFF
--- a/core-services/google.js
+++ b/core-services/google.js
@@ -14,6 +14,6 @@ if (Meteor.isClient) {
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);
-    Package.google.Google.requestCredential(options, credentialRequestCompleteCallback);
+    Package['google-oauth'].Google.requestCredential(options, credentialRequestCompleteCallback);
   };
 }


### PR DESCRIPTION
To follow new naming of package from Meteor, package 'google' is now 'google-oauth'