### PR TITLE
Discord OAuth Integration

### DIFF
--- a/community-services/discord.js
+++ b/community-services/discord.js
@@ -1,0 +1,18 @@
+if (Meteor.isClient) {
+  Meteor.linkWithDiscord = function (options, callback) {
+    if (!Meteor.userId()) {
+      throw new Meteor.Error(402, 'Please login to an existing account before link.');
+    }
+    if (!Package['lichthagel:accounts-discord']) {
+      throw new Meteor.Error(403, 'Please include lichthagel:accounts-discord package')
+    }
+
+    if (! callback && typeof options === "function") {
+      callback = options;
+      options = null;
+    }
+
+    var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);
+    Discord.requestCredential(options, credentialRequestCompleteCallback);
+  };
+}

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ var path = Npm.require('path');
 
 Package.describe({
   "summary": "Meteor external service link system",
-  "version": "1.2.10",
+  "version": "1.2.10_1",
   "git": "https://github.com/yubozhao/meteor-link-accounts",
   "name": "bozhao:link-accounts",
   "description": "Link social accounts for Meteor"

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ var path = Npm.require('path');
 
 Package.describe({
   "summary": "Meteor external service link system",
-  "version": "1.2.10_1",
+  "version": "1.2.10_3",
   "git": "https://github.com/yubozhao/meteor-link-accounts",
   "name": "bozhao:link-accounts",
   "description": "Link social accounts for Meteor"
@@ -28,6 +28,7 @@ Package.on_use(function (api) {
     'core-services/weibo.js',
     'community-services/angellist.js',
     'community-services/dropbox.js',
+    'community-services/discord.js',
     'community-services/edmodo.js',
     'community-services/instagram.js',
     'community-services/linkedin.js',


### PR DESCRIPTION
I've added a community integration with the discord OAuth package at:
https://github.com/Lichthagel/meteor-accounts-discord

The integration itself works well. There are a couple changes to the underlying package that are needed to update it to the current Discord API. I'll be sending a pull request to the original author for those changes as well.
