### PR TITLE
Fixed checking whether accounts-facebook exist or not

### DIFF
--- a/core-services/facebook.js
+++ b/core-services/facebook.js
@@ -17,7 +17,7 @@ if (Meteor.isClient) {
         throw new Meteor.Error(403, 'Please include btafel:accounts-facebook-cordova package or cordova-fb package')
       }
     } else {
-      if (!Package['accounts-facebook'] || !facebookPackage) {
+      if (!facebookPackage) {
         throw new Meteor.Error(403, 'Please include accounts-facebook and facebook-oauth package or cordova-fb package')
       }
     }

--- a/core-services/google.js
+++ b/core-services/google.js
@@ -1,11 +1,10 @@
-
 if (Meteor.isClient) {
   Meteor.linkWithGoogle = function (options, callback) {
     if (!Meteor.userId()) {
       throw new Meteor.Error(402, 'Please login to an existing account before link.');
     }
     if(!Package['accounts-google'] && !Package['google']) {
-      throw new Meteor.Error(403, 'Please include accounts-google and google package')
+      throw new Meteor.Error(403, 'Please include accounts-google and google package');
     }
 
     if (!callback && typeof options === "function") {
@@ -14,6 +13,13 @@ if (Meteor.isClient) {
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);
-    Package['google-oauth'].Google.requestCredential(options, credentialRequestCompleteCallback);
+    if(Meteor.isCordova){
+      window.plugins.googleplus.login(
+        {},
+        (serviceData) => Meteor.call('cordovaGoogle', 'google', serviceData,(err) => callback(err))
+      );
+    }else{
+      Package['google-oauth'].Google.requestCredential(options, credentialRequestCompleteCallback);
+    }
   };
 }

--- a/link_accounts_server.js
+++ b/link_accounts_server.js
@@ -27,6 +27,12 @@ Accounts.registerLoginHandler(function (options) {
       result.serviceName, result.serviceData, result.options);
 });
 
+Meteor.methods({
+  'cordovaGoogle'(serviceName,serviceData){
+    Accounts.LinkUserFromExternalService(serviceName, serviceData, {});//passing empty object cause in any case it is not used
+  }
+});
+
 Accounts.LinkUserFromExternalService = function (serviceName, serviceData, options) {
   options = _.clone(options || {});
 
@@ -38,7 +44,7 @@ Accounts.LinkUserFromExternalService = function (serviceName, serviceData, optio
     throw new Meteor.Error(
       "Can't use LinkUserFromExternalService with internal service: "
         + serviceName);
-  if (!_.has(serviceData, 'id'))
+  if (!( _.has(serviceData, 'id') || _.has(serviceData, 'userId')))
     throw new Meteor.Error(
       "'id' missing from service data for: " + serviceName);
 
@@ -48,7 +54,12 @@ Accounts.LinkUserFromExternalService = function (serviceName, serviceData, optio
     return new Meteor.Error('User not found for LinkUserFromExternalService');
   }
   var checkExistingSelector = {};
+  if(!!serviceData.userId){
+    serviceData.id = serviceData.userId;
+    delete serviceData.userId;
+  }
   checkExistingSelector['services.' + serviceName + '.id'] = serviceData.id;
+  
   var existingUsers = Meteor.users.find(checkExistingSelector).fetch();
   if (existingUsers.length) {
     existingUsers.forEach(function(existingUser) {


### PR DESCRIPTION
I`m using your package in meteor cordova app, and there is a conflict when using `accounts-facebook-cordova` package with it.
`accounts-facebook-cordova` cannot be installed with `accounts-facebook` also installed, but it is a wrapper on a `accounts-facebook`,so on web i have an error that tells me i need to install `accounts-facebook` package but i actually don`t need to, cause `accounts-facebook-cordova` falls back to `accounts-facebook` on web.
I`ve removed checking whether the `accounts-facebook` is installed and everything seems to work properly.Can you check it out?