### PR TITLE
Fix syntax error on browsers that not support arrow function

### DIFF
--- a/core-services/google.js
+++ b/core-services/google.js
@@ -16,7 +16,12 @@ if (Meteor.isClient) {
     if(Meteor.isCordova){
       window.plugins.googleplus.login(
         {},
-        (serviceData) => Meteor.call('cordovaGoogle', 'google', serviceData,(err) => callback(err))
+        function (serviceData) {
+          Meteor.call('cordovaGoogle', 'google', serviceData);
+        },
+        function (err) {
+          callback(err);
+        }
       );
     }else{
       Package['google-oauth'].Google.requestCredential(options, credentialRequestCompleteCallback);

--- a/link_accounts_server.js
+++ b/link_accounts_server.js
@@ -28,7 +28,7 @@ Accounts.registerLoginHandler(function (options) {
 });
 
 Meteor.methods({
-  'cordovaGoogle'(serviceName,serviceData){
+  'cordovaGoogle': function (serviceName, serviceData) {
     Accounts.LinkUserFromExternalService(serviceName, serviceData, {});//passing empty object cause in any case it is not used
   }
 });


### PR DESCRIPTION
Fix #74 
This issue also occur on IE11, fixed by replacing arrow function to anonymous function